### PR TITLE
Custom formatting via config.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added custom formatting options via config.toml. #8 by @dotaxis 
 
 ## [0.2.5] - 2024-04-27
 ### Changed

--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ Removed from library!
 {"text":"Twenty One Pilots - Bounce Man","tooltip":"Scaled And Icy","class":["playing"]}
 ```
 
-Liked songs also have a `+` instead of a `-` between the artist and song title.
-
+By default, liked songs also have a `+` instead of a `-` between the artist and song title.
 
 ## Bar Integration
 
@@ -91,6 +90,35 @@ exec = spotifatius monitor --output-type polybar
 tail = true
 click-right = spotifatius toggle-liked
 ```
+
+## config.toml options
+
+### format
+
+The JSON output can be formatted using the `format` var in config.toml:
+
+Example 1:
+```toml
+format = "{status} {title} {separator} {artist}" # {"text":"  Bounce Man + Twenty One Pilots","tooltip":"Scaled And Icy","class":["liked", "playing"]}
+```
+
+Example 2:
+```toml
+format = "{artist} -- {title}" # {"text":"Twenty One Pilots -- Bounce Man","tooltip":"Scaled And Icy","class":["liked", "playing"]}
+```
+
+Default format is `{artist} {separator} {title}`
+
+Available options:
+| Name        | Function |
+| ---         | --- |
+| {status}    | Unicode symbol for playing/paused track |
+| {title}     | Current track title |
+| {artist}    | Current track artist |
+| {separator} | + if current track is a liked song, - if not |
+
+
+### polybar
 
 Polybar maps the classes from the [waybar](#waybar) output to colors that you can define in your config file `~/.config/spotifatius/config.toml`:
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ click-right = spotifatius toggle-liked
 
 ### format
 
+🗒 **Note:** These formatting options are not yet final and might change in upcoming versions. They won't be considered breaking changes as a result, though a minor version bump will be done if this changes. [More info.](https://github.com/AndreasBackx/spotifatius/pull/8)
+
 The JSON output can be formatted using the `format` var in config.toml:
 
 Example 1:

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -37,6 +37,7 @@ pub struct Monitor {
 
 pub async fn run(opts: Monitor) -> Result<()> {
     let config = get_config(opts.config)?;
+    let output_format = config.clone().format;
     let formatter = OutputFormatter {
         output_type: opts.output_type,
         config,
@@ -69,7 +70,16 @@ pub async fn run(opts: Monitor) -> Result<()> {
                     class.push(status.into());
                     let text = match (track.artist, track.title) {
                         (Some(artist), Some(title)) => {
-                            format!("{} {} {}", artist, separator, title)
+                            let status_icon = match status {
+                                TrackStatus::Playing => " ",
+                                TrackStatus::Paused => " ",
+                                _ => "" // unable to get player state
+                            };
+                            output_format
+                                .replace("{artist}", &artist)
+                                .replace("{title}", &title)
+                                .replace("{separator}", separator)
+                                .replace("{status}", status_icon)
                         }
                         (Some(artist), None) => artist,
                         (None, Some(title)) => title,

--- a/src/commands/output.rs
+++ b/src/commands/output.rs
@@ -2,8 +2,10 @@ use anyhow::Result;
 use clap::ArgEnum;
 use serde::Serialize;
 
-use crate::shared::config::Config;
-
+use crate::{
+    shared::config::Config,
+    server::grpc::api::{MonitorResponse, TrackStatus},
+};
 #[derive(Serialize, Clone)]
 pub struct Output {
     pub text: String,
@@ -25,6 +27,58 @@ pub struct OutputFormatter {
 }
 
 impl OutputFormatter {
+    pub fn format_output(&self, response: MonitorResponse, status: TrackStatus, output_format: &str) -> Output {
+        if let Some(track) = response.track {
+            let mut class = vec![];
+            let mut separator = "-";
+            if response.is_liked.unwrap_or_default() {
+                class.push("liked".to_string());
+                separator = "+";
+            }
+            class.push(status.into());
+            let text = match (track.artist, track.title) {
+                (Some(artist), Some(title)) => {
+                    let status_icon = match status {
+                        TrackStatus::Playing => " ",
+                        TrackStatus::Paused => " ",
+                        _ => "" // unable to get player state
+                    };
+                    output_format
+                        .replace("{artist}", &artist)
+                        .replace("{title}", &title)
+                        .replace("{separator}", separator)
+                        .replace("{status}", status_icon)
+                }
+                (Some(artist), None) => artist,
+                (None, Some(title)) => title,
+                (None, None) => "".to_string(),
+            };
+            Output {
+                text,
+                tooltip: track.album,
+                class: Some(class),
+            }
+        } else if status == TrackStatus::Added {
+            Output {
+                text: "Added to library!".to_string(),
+                tooltip: None,
+                class: Some(vec![status.into()]),
+            }
+        } else if status == TrackStatus::Removed {
+            Output {
+                text: "Removed from library!".to_string(),
+                tooltip: None,
+                class: Some(vec![status.into()]),
+            }
+        } else {
+            Output {
+                text: "".to_string(),
+                tooltip: None,
+                class: None,
+            }
+        }
+    }
+
     pub fn print(&self, output: Output) -> Result<()> {
         match self.output_type {
             OutputType::Waybar => {

--- a/src/commands/output.rs
+++ b/src/commands/output.rs
@@ -51,6 +51,7 @@ impl OutputFormatter {
                     output_format
                         .replace("{artist}", &artist)
                         .replace("{title}", &title)
+                        .replace("{album}", track.album.as_ref().unwrap())
                         .replace("{separator}", separator)
                         .replace("{status}", status_icon)
                         .replace("{liked}", liked_icon)

--- a/src/commands/output.rs
+++ b/src/commands/output.rs
@@ -28,6 +28,7 @@ pub struct OutputFormatter {
 
 impl OutputFormatter {
     pub fn format_output(&self, response: MonitorResponse, status: TrackStatus, output_format: &str) -> Output {
+        let text_template = &self.config.text_template;
         if let Some(track) = response.track {
             let mut class = vec![];
             let mut separator = "-";
@@ -39,15 +40,20 @@ impl OutputFormatter {
             let text = match (track.artist, track.title) {
                 (Some(artist), Some(title)) => {
                     let status_icon = match status {
-                        TrackStatus::Playing => " ",
-                        TrackStatus::Paused => " ",
+                        TrackStatus::Playing => &text_template.playing,
+                        TrackStatus::Paused => &text_template.paused,
                         _ => "" // unable to get player state
+                    };
+                    let liked_icon = match class.contains(&"liked".to_string()) {
+                        true => &text_template.liked,
+                        _ => "" // not liked, so display no icon
                     };
                     output_format
                         .replace("{artist}", &artist)
                         .replace("{title}", &title)
                         .replace("{separator}", separator)
                         .replace("{status}", status_icon)
+                        .replace("{liked}", liked_icon)
                 }
                 (Some(artist), None) => artist,
                 (None, Some(title)) => title,

--- a/src/commands/output.rs
+++ b/src/commands/output.rs
@@ -32,7 +32,8 @@ impl OutputFormatter {
         if let Some(track) = response.track {
             let mut class = vec![];
             let mut separator = "-";
-            if response.is_liked.unwrap_or_default() {
+            let is_liked = response.is_liked.unwrap_or_default();
+            if is_liked {
                 class.push("liked".to_string());
                 separator = "+";
             }
@@ -44,9 +45,11 @@ impl OutputFormatter {
                         TrackStatus::Paused => &text_template.paused,
                         _ => "" // unable to get player state
                     };
-                    let liked_icon = match class.contains(&"liked".to_string()) {
-                        true => &text_template.liked,
-                        _ => "" // not liked, so display no icon
+                    let liked_icon = if is_liked {
+                    	&text_template.liked
+                    } else {
+                    	"" // Display no icon if not liked
+                    }
                     };
                     output_format
                         .replace("{artist}", &artist)

--- a/src/commands/output.rs
+++ b/src/commands/output.rs
@@ -49,7 +49,6 @@ impl OutputFormatter {
                     	&text_template.liked
                     } else {
                     	"" // Display no icon if not liked
-                    }
                     };
                     output_format
                         .replace("{artist}", &artist)

--- a/src/shared/config.rs
+++ b/src/shared/config.rs
@@ -7,10 +7,12 @@ use tracing::{debug, warn};
 pub const DEFAULT_CONFIG_FOLDER: &str = "~/.config/spotifatius";
 pub const DEFAULT_CONFIG_PATH: &str = "~/.config/spotifatius/config.toml";
 
-#[derive(Clone, Debug, Deserialize, Default)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Config {
     #[serde(default = "default_polybar_config")]
     pub polybar: PolybarConfig,
+    #[serde(default = "default_format")]
+    pub format: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]
@@ -22,6 +24,19 @@ pub struct PolybarConfig {
 fn default_polybar_config() -> PolybarConfig {
     PolybarConfig {
         colors: HashMap::new(),
+    }
+}
+
+fn default_format() -> String {
+    "{artist} {separator} {title}".to_string()
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            polybar: default_polybar_config(),
+            format: default_format(),
+        }
     }
 }
 

--- a/src/shared/config.rs
+++ b/src/shared/config.rs
@@ -7,7 +7,7 @@ use tracing::{debug, warn};
 pub const DEFAULT_CONFIG_FOLDER: &str = "~/.config/spotifatius";
 pub const DEFAULT_CONFIG_PATH: &str = "~/.config/spotifatius/config.toml";
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Default)]
 pub struct Config {
     #[serde(default = "default_polybar_config")]
     pub polybar: PolybarConfig,
@@ -29,15 +29,6 @@ fn default_polybar_config() -> PolybarConfig {
 
 fn default_format() -> String {
     "{artist} {separator} {title}".to_string()
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Config {
-            polybar: default_polybar_config(),
-            format: default_format(),
-        }
-    }
 }
 
 pub fn resolve_home_path(path: PathBuf) -> Result<PathBuf> {
@@ -73,8 +64,8 @@ pub fn get_config(config_path: PathBuf) -> Result<Config> {
                 .with_context(|| format!("could not parse {}", path.display()))
         }
         Err(err) => {
-            warn!("{err}");
-            Ok(Config::default())
+            warn!("{err}: Using default config");
+            Ok(toml::from_str::<Config>("")?)
         }
     }
 }

--- a/src/shared/config.rs
+++ b/src/shared/config.rs
@@ -13,6 +13,8 @@ pub struct Config {
     pub polybar: PolybarConfig,
     #[serde(default = "default_format")]
     pub format: String,
+	#[serde(default)]
+    pub text_template: TemplateConfig,
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]
@@ -29,6 +31,28 @@ fn default_polybar_config() -> PolybarConfig {
 
 fn default_format() -> String {
     "{artist} {separator} {title}".to_string()
+}
+
+#[derive(Clone, Debug, Deserialize, Default)]
+pub struct TemplateConfig {
+    #[serde(default = "default_playing_text")]
+	pub playing: String,
+    #[serde(default = "default_paused_text")]
+	pub paused: String,
+    #[serde(default = "default_liked_text")]
+    pub liked: String,
+}
+
+fn default_playing_text() -> String {
+    " ".to_string()
+}
+
+fn default_paused_text() -> String {
+    " ".to_string()
+}
+
+fn default_liked_text() -> String {
+    " ".to_string()
 }
 
 pub fn resolve_home_path(path: PathBuf) -> Result<PathBuf> {


### PR DESCRIPTION
This allows customizing the output of spotifatius using the config.toml.

Includes `{status}` var which will print a play/pause unicode character depending on if the track is playing or paused.

Open to any suggestions on how to make it better, just let me know.

Also address https://github.com/AndreasBackx/spotifatius/issues/5