### PR TITLE
Update default redirect URI to be usable to new Spostify policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated redirect URI to be `http://127.0.0.1:8000` as `http://localhost` is disallowed for new apps.
 
 ## [0.2.6] - 2024-10-19
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A simple Spotify CLI primarily made for monitoring what songs you're listening t
 First make sure the `RSPOTIFY_CLIENT_ID` and `RSPOTIFY_CLIENT_SECRET` environment
 variables are available in your shell environment. They need to contain the
 Spotify developer Client ID and secret. Follow [Spotify's Developer Documentation](https://developer.spotify.com/documentation/web-api/concepts/apps)
-on how to set that up, make sure the redirect URI is set to `https://127.0.0.1:8000`.
+on how to set that up, make sure the redirect URI is set to `http://127.0.0.1:8000`.
 Once done, run `spotifatius monitor` once to setup Spotify access tokens:
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A simple Spotify CLI primarily made for monitoring what songs you're listening t
 First make sure the `RSPOTIFY_CLIENT_ID` and `RSPOTIFY_CLIENT_SECRET` environment
 variables are available in your shell environment. They need to contain the
 Spotify developer Client ID and secret. Follow [Spotify's Developer Documentation](https://developer.spotify.com/documentation/web-api/concepts/apps)
-on how to set that up, make sure the redirect URI is set to `http://localhost`.
+on how to set that up, make sure the redirect URI is set to `https://127.0.0.1:8000`.
 Once done, run `spotifatius monitor` once to setup Spotify access tokens:
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,12 +8,17 @@ use anyhow::Result;
 
 use clap::Parser;
 use commands::{monitor, toggle_liked};
+use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::WARN.into())
+                .from_env_lossy(),
+        )
         .pretty()
         .init();
     let root_opts = Opts::parse();

--- a/src/server/liked_tracker.rs
+++ b/src/server/liked_tracker.rs
@@ -37,7 +37,7 @@ impl Tracks {
 impl LikedTracker {
     pub async fn new(change_tx: Sender<ChangeEvent>) -> Result<Self> {
         let oauth = OAuth {
-            redirect_uri: "http://localhost".to_string(),
+            redirect_uri: "https://127.0.0.1:8000".to_string(),
             scopes: scopes!("user-library-read", "user-library-modify"),
             ..Default::default()
         };

--- a/src/server/liked_tracker.rs
+++ b/src/server/liked_tracker.rs
@@ -6,7 +6,7 @@ use rspotify::{
     Credentials, OAuth, DEFAULT_CACHE_PATH,
 };
 use tokio::sync::mpsc::Sender;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::shared::config::{resolve_home_path, DEFAULT_CONFIG_FOLDER};
 
@@ -37,10 +37,11 @@ impl Tracks {
 impl LikedTracker {
     pub async fn new(change_tx: Sender<ChangeEvent>) -> Result<Self> {
         let oauth = OAuth {
-            redirect_uri: "https://127.0.0.1:8000".to_string(),
+            redirect_uri: "http://127.0.0.1:8000".to_string(),
             scopes: scopes!("user-library-read", "user-library-modify"),
             ..Default::default()
         };
+        warn!("If you see a redirect error, please edit your Spotify app to allow the redirect URI: http://127.0.0.1:8000. This was changed in 0.3.0. See https://github.com/AndreasBackx/spotifatius/pull/9.");
         let creds = Credentials::from_env().context(
             "Could not find RSPOTIFY_CLIENT_(ID|SECRET) environment variables",
         )?;


### PR DESCRIPTION
Trying to use this software I bumped with a change on Spotify policies that wouldn't let me use `http://localhost` as a redirect uri. 
So I changed the URI you use for getting auth tokens to `https://127.0.0.1:8000` which is what the docs recommend for loopback. 
Also updated the README so it will help newcomers